### PR TITLE
Update with queue_size to avoid warnings in indigo

### DIFF
--- a/concert_scheduler_requests/src/concert_scheduler_requests/requester.py
+++ b/concert_scheduler_requests/src/concert_scheduler_requests/requester.py
@@ -163,7 +163,7 @@ class Requester:
                                     self._feedback,
                                     queue_size=1, tcp_nodelay=True)
         self.pub = rospy.Publisher(self.pub_topic, SchedulerRequests,
-                                   latch=True)
+                                   latch=True, queue_size=5)
         self.time_delay = rospy.Duration(1.0 / frequency)
         self._set_timer()
 

--- a/concert_scheduler_requests/src/concert_scheduler_requests/scheduler.py
+++ b/concert_scheduler_requests/src/concert_scheduler_requests/scheduler.py
@@ -89,7 +89,7 @@ class _RequesterStatus:
                                                self.sched.topic)
         rospy.loginfo('requester feedback topic: ' + feedback_topic)
         self.pub = rospy.Publisher(feedback_topic, SchedulerRequests,
-                                   latch=True)
+                                   latch=True, queue_size=5)
 
     def contact(self):
         """ Contact newly-connected requester. """


### PR DESCRIPTION
They just implemented the warning to encourage rospy publishers to specify a queue_size in indigo.
- http://lists.ros.org/pipermail/ros-users/2014-March/068333.html
- http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers

It's very spammy :neckbeard:
